### PR TITLE
fix front end iframe blocking issue

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
@@ -64,9 +64,7 @@ function checkAccountAndFetchDetail(){
     success(data) {
       if (data !== null) {
         if (data.hasBoltAccount){
-          authorizeUser(customerEmail).then(function(){
-            emailInput.removeEventListener("focusout")
-          })
+          authorizeUser(customerEmail);
         }
       }
     },


### PR DESCRIPTION
Asana: https://app.asana.com/0/1201931884901947/1202556680280215

This change unbind the focusout event listener once it's triggered once so the iframe will go away if it's closed by the user unless refreshing the page. In the demo, I can still move around once I closed the iframe initially because it's not triggering the callback to load the iframe multiple times. And the whole logged in flow still works well.

Demo:

https://user-images.githubusercontent.com/79222730/177860021-44727af1-cc49-4d10-b260-69188180fa39.mov

 