### PR TITLE
fix displaying payment tab

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/templates/default/checkout/billing/paymentOptions/bolt/paymentContent.isml
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/templates/default/checkout/billing/paymentOptions/bolt/paymentContent.isml
@@ -34,7 +34,7 @@
                 <span>${Resource.msg('add.new.card', 'bolt', null)}</span>
             </label>
     </isif>
-    <div class="bolt-pay ${loginAsBoltUser && pdict.boltStoredPaymentMethods ? 'd-none' : ''}">
+    <div class="bolt-pay ${loginAsBoltUser && pdict.boltStoredPaymentMethods && pdict.boltStoredPaymentMethods.length ? 'd-none' : ''}">
         <fieldset class="payment-form-fields">
             <input type="hidden" class="form-control" name="${pdict.forms.billingForm.paymentMethod.htmlName}"
                 value="${paymentOption.ID}">


### PR DESCRIPTION
asana: https://app.asana.com/0/1202482032981150/1202640698278473
The payment tab used to be not displayed when there is no payment on the account + loggedin. this Pr fixes that
