### PR TITLE
fix missing phone number in billing address

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
@@ -68,7 +68,8 @@ exports.addAccountDetailsToBasket = function(shopperDetails){
         const addPaymentResult = addPaymentMethodInfoToBasket(basket, shopperDetails.payment_methods);
 
         // hacky fix for missing phone number in the billing address
-        if(!basket.getBillingAddress().getPhone()){
+        // note: there could be email only account so we need to check if there is a phone number for this account
+        if(!basket.getBillingAddress().getPhone() && shopperDetails.profile.phone){
             Transaction.wrap(function (){
                 basket.getBillingAddress().setPhone(shopperDetails.profile.phone);
             })


### PR DESCRIPTION
asana: https://app.asana.com/0/1202482032981150/1202640698278485

If the phone number is missing from the billing address returned from /v1/account, we use the one in the profile. 