### PR TITLE
email value should be encode as URI Component

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
@@ -19,7 +19,7 @@ var log = LogUtils.getLogger('CheckAccount');
 
 server.get('AccountExists', server.middleware.https, function (req, res, next) {
     var email = req.querystring.email;
-    var response = httpUtils.restAPIClient('GET', constants.CHECK_ACCOUNT_EXIST_URL + email);
+    var response = httpUtils.restAPIClient('GET', constants.CHECK_ACCOUNT_EXIST_URL + encodeURIComponent(email));
 
     var returnObject = {};
     if (response.status === HttpResult.OK) {
@@ -59,9 +59,9 @@ server.get('GetAccountDetails', server.middleware.https, function (req, res, nex
     if (response.status === HttpResult.OK) {
         var shopperDetails = response.result;
         var addAccountDetailsResult = account.addAccountDetailsToBasket(shopperDetails);
-        if (addAccountDetailsResult.redirectShipping){
+        if (addAccountDetailsResult.redirectShipping) {
             returnObject.redirectUrl = URLUtils.https('Checkout-Begin').append('stage', 'shipping').toString();
-        } else if (addAccountDetailsResult.redirectBilling){
+        } else if (addAccountDetailsResult.redirectBilling) {
             returnObject.redirectUrl = URLUtils.https('Checkout-Begin').append('stage', 'payment').toString();
         } else {
             returnObject.redirectUrl = URLUtils.https('Checkout-Begin').append('stage', 'placeOrder').toString();


### PR DESCRIPTION
Issue: when email address contains special character like '+', it's causing issue to send check account exist request. email value should be encode as URI Component.

Solution: use SFCC global function `encodeURIComponent` to encode the email value.

Fix:
![Screen Shot 2022-07-21 at 10 27 25 AM](https://user-images.githubusercontent.com/93539162/180239092-b22f9800-7bf1-4cd2-907f-0cdb8a6aa11e.png)

