### PR TITLE
Fixed billing address overwritten issue.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/CheckoutShippingServices.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/CheckoutShippingServices.js
@@ -18,7 +18,6 @@ var AddressModel = require('*/cartridge/models/address');
 
 server.extend(module.superModule);
 
-
 /**
  * Set billing address data with default shipping address if no billing matching address id is set. Save Bolt shippping address id.
  */
@@ -27,12 +26,16 @@ server.append('SubmitShipping', function (req, res, next) {
     this.on('route:BeforeComplete', function (req, res) { // eslint-disable-line no-shadow
         try {
             var order = res.viewData.order;
-            if (order && order.billing && empty(order.billing.matchingAddressId) && currentBasket.getDefaultShipment()) {
-                order.billing.matchingAddressId = currentBasket.getDefaultShipment().UUID;
-                order.billing.billingAddress = new AddressModel(currentBasket.getDefaultShipment().getShippingAddress());
-                res.json({
-                    order: order
-                });
+            if (order && currentBasket) {
+                var emptyBillingAddressInBasket = boltAccountUtils.isEmptyAddress(currentBasket.getBillingAddress());
+                var noBillingAddressData = empty(order.billing.matchingAddressId) && emptyBillingAddressInBasket;
+                if (noBillingAddressData && order.billing && currentBasket.getDefaultShipment()) {
+                    order.billing.matchingAddressId = currentBasket.getDefaultShipment().UUID;
+                    order.billing.billingAddress = new AddressModel(currentBasket.getDefaultShipment().getShippingAddress());
+                    res.json({
+                        order: order
+                    });
+                }
             }
         } catch (e) {
             log.error(e.message);

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
@@ -256,3 +256,27 @@ exports.isAnyAddressDataMissing = function (address) {
 exports.checkEmptyValue = function (list) {
     return list.includes('');
 }
+
+
+/**
+ * Check if it is a empty SFCC address object
+ * @param {dw.order.OrderAddress} address - SFCC address object
+ * @return {boolean} true if all the fields are empty otherwise false
+ */
+exports.isEmptyAddress = function(address) {
+    if (address === null) {
+        return true;
+    }
+    return [
+        address.firstName,
+        address.lastName,
+        address.address1,
+        address.city,
+        address.stateCode,
+        address.countryCode && address.countryCode.value ? address.countryCode.value : null,
+        address.postalCode,
+        address.phone
+    ].every(function(field){
+        return field === null;
+    })
+}


### PR DESCRIPTION
Asana task: https://app.asana.com/0/1201931884901947/1202664358000893/f

Issue: when shopper goes to billing step, the billing address data is overwritten by shipping address data

------------
Test data:
shipping address in shopper account:
![Screen Shot 2022-07-26 at 5 45 22 PM](https://user-images.githubusercontent.com/93539162/181119696-a6a7a521-8e08-467c-aa35-1de2d1b44f30.png)


billing address for default credit card in shopper account:
![Screen Shot 2022-07-26 at 5 45 14 PM](https://user-images.githubusercontent.com/93539162/181119745-0e2fadfa-aebf-4a9e-b24d-08437ff10730.png)



Before fix:

https://user-images.githubusercontent.com/93539162/181119778-b676cfb3-7254-43f5-897e-c6cab7001955.mov



After fix:

https://user-images.githubusercontent.com/93539162/181119790-6eab3d05-f09b-4b83-a9bb-429658f24e2a.mov


