### PR TITLE
Remove custom field basketId from SFCC payment instrument object since it's not needed.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -65,7 +65,6 @@ function handle(currentBasket, paymentInformation, paymentMethodID, req) {
             paymentInstrument.setCreditCardExpirationMonth(selectedBoltPayment.exp_month);
             paymentInstrument.setCreditCardExpirationYear(selectedBoltPayment.exp_year);
             paymentInstrument.custom.boltPaymentMethodId = selectedPaymentID;
-            paymentInstrument.custom.basketId = currentBasket.UUID;
         });
     } else {
         Transaction.wrap(function () {
@@ -74,7 +73,6 @@ function handle(currentBasket, paymentInformation, paymentMethodID, req) {
             paymentInstrument.setCreditCardExpirationMonth(paymentInformation.expirationMonth);
             paymentInstrument.setCreditCardExpirationYear(paymentInformation.expirationYear);
             paymentInstrument.setCreditCardToken(paymentInformation.creditCardToken);
-            paymentInstrument.custom.basketId = currentBasket.UUID;
             paymentInstrument.custom.boltCardBin = paymentInformation.bin;
             paymentInstrument.custom.boltTokenType = paymentInformation.token_type;
             paymentInstrument.custom.boltCreateAccount = paymentInformation.createAccount;
@@ -154,10 +152,6 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
 function getAuthRequest(order, paymentInstrument) {
     if (empty(paymentInstrument)) {
         return { error: true, errorMsg: 'Missing payment instrument.' };
-    }
-
-    if (empty(paymentInstrument.custom.basketId)) {
-        return { error: true, errorMsg: 'SFCC basket ID not found.' };
     }
 
     if (empty(order.billingAddress)) {

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
@@ -192,7 +192,6 @@ function addPaymentMethodInfoToBasket(basket, boltPaymentMethods){
         paymentInstrument.setCreditCardExpirationMonth(exp_month);
         paymentInstrument.setCreditCardExpirationYear(exp_year);
 
-        paymentInstrument.custom.basketId = basket.UUID;
         // TODO: don't have this info at this point, do we need to add it later
         //paymentInstrument.custom.boltCardBin = paymentInformation.bin;
         paymentInstrument.custom.boltPaymentMethodId = boltPaymentMethodID;

--- a/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
+++ b/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
@@ -87,13 +87,6 @@
         <externally-managed-flag>false</externally-managed-flag>
         <default-value>false</default-value>
       </attribute-definition>
-      <attribute-definition attribute-id="basketId">
-        <display-name xml:lang="x-default">SFCC Basket ID</display-name>
-        <type>string</type>
-        <mandatory-flag>false</mandatory-flag>
-        <externally-managed-flag>false</externally-managed-flag>
-        <min-length>0</min-length>
-      </attribute-definition>
       <attribute-definition attribute-id="boltPaymentMethodId">
         <display-name xml:lang="x-default">Bolt Payment Method ID</display-name>
         <type>string</type>


### PR DESCRIPTION
See title.