### PR TITLE
include customized FED address handling logic.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/checkout/checkout.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/checkout/checkout.js
@@ -7,6 +7,7 @@ var formHelpers = require('base/checkout/formErrors');
 var scrollAnimate = require('base/components/scrollAnimate');
 
 var billingHelpers = require('./billing');
+var addressHelpers = require('./address');
 
 (function ($) {
 
@@ -602,7 +603,7 @@ var billingHelpers = require('./billing');
     };
 }(jQuery));
 
-[billingHelpers].forEach(function (library) {
+[billingHelpers, addressHelpers].forEach(function (library) {
     Object.keys(library).forEach(function (item) {
       if (typeof library[item] === 'object') {
         base[item] = $.extend({}, base[item], library[item]);


### PR DESCRIPTION
Issue: When bolt user use a new shipping address for checkout, seems like it's overwriting the old shipping address in the shopper account instead of creating a new one

Before fix:


https://user-images.githubusercontent.com/93539162/181573469-646adc4d-f556-48fc-9f81-7ab6cf3919db.mov



After fix - add a new address:



https://user-images.githubusercontent.com/93539162/181573483-fd50aec5-e163-4826-bfa1-18e02960f1f5.mov


After fix - update a current address:

https://user-images.githubusercontent.com/93539162/181573980-af347798-b773-4ad2-893d-1fe3ce8e2983.mov


