### PR TITLE
Move bolt data from session.privacy to session.custom

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
@@ -39,11 +39,11 @@ server.get('FetchOauthToken', server.middleware.https, function (req, res, next)
     if (response.status === HttpResult.OK) {
         returnObject.accessToken = response.result.access_token;
         returnObject.refreshToken = response.result.refresh_token;
-        session.privacy.boltOauthToken = response.result.access_token;
-        session.privacy.boltRefreshToken = response.result.refresh_token;
-        session.privacy.boltRefreshTokenScope = response.result.refresh_token_scope;
+        session.custom.boltOauthToken = response.result.access_token;
+        session.custom.boltRefreshToken = response.result.refresh_token;
+        session.custom.boltRefreshTokenScope = response.result.refresh_token_scope;
         // store OAuth token expire time in milliseconds, 1000 -> ONE_SECOND
-        session.privacy.boltOauthTokenExpire = response.result.expires_in * 1000 + new Date().getTime();
+        session.custom.boltOauthTokenExpire = response.result.expires_in * 1000 + new Date().getTime();
     } else {
         var log = LogUtils.getLogger('Oauth');
         var errorMsg = "Failed to fetch Oauth Token." + !empty(response.errors) && !empty(response.errors[0].message) ? response.errors[0].message : "";

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/oauth.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/oauth.js
@@ -33,8 +33,8 @@ exports.fetchNewToken = function (code, scope) {
  */
 exports.getOauthToken = function () {
     // Oauth token will not expire in 4 seconds, use the current Oauth token in session
-    if ((session.privacy.boltOauthTokenExpire - new Date().getTime()) > constants.OAUTH_TOKEN_REFRESH_TIME) {
-        return session.privacy.boltOauthToken;
+    if ((session.custom.boltOauthTokenExpire - new Date().getTime()) > constants.OAUTH_TOKEN_REFRESH_TIME) {
+        return session.custom.boltOauthToken;
     }
 
     // refresh OAuth token
@@ -43,25 +43,25 @@ exports.getOauthToken = function () {
 
 function refreshToken() {
     var boltOauthToken;
-    if (!session.privacy.boltRefreshToken || !session.privacy.boltRefreshTokenScope) {
+    if (!session.custom.boltRefreshToken || !session.custom.boltRefreshTokenScope) {
         log.error('Refresh token or refresh token scope is missing.');
         return boltOauthToken;
     }
 
     var config = preferences.getSitePreferences();
     var payload = 'grant_type=refresh_token&refresh_token='
-        .concat(session.privacy.boltRefreshToken, '&scope=')
-        .concat(session.privacy.boltRefreshTokenScope, '&client_secret=')
+        .concat(session.custom.boltRefreshToken, '&scope=')
+        .concat(session.custom.boltRefreshTokenScope, '&client_secret=')
         .concat(config.boltApiKey, '&client_id=')
         .concat(config.boltMultiPublishableKey);
 
     var response = httpUtils.restAPIClient('POST', constants.OAUTH_TOKEN_URL, payload, 'application/x-www-form-urlencoded');
     if (response.status === HttpResult.OK && !empty(response.result)) {
-        session.privacy.boltOauthToken = response.result.access_token;
-        session.privacy.boltRefreshToken = response.result.refresh_token;
-        session.privacy.boltRefreshTokenScope = response.result.refresh_token_scope;
+        session.custom.boltOauthToken = response.result.access_token;
+        session.custom.boltRefreshToken = response.result.refresh_token;
+        session.custom.boltRefreshTokenScope = response.result.refresh_token_scope;
         // store OAuth token expire time in milliseconds, 1000 -> ONE_SECOND
-        session.privacy.boltOauthTokenExpire = Date.now() + response.result.expires_in * 1000;
+        session.custom.boltOauthTokenExpire = Date.now() + response.result.expires_in * 1000;
         boltOauthToken = response.result.access_token;
     } else {
         log.error('Failed to refresh Oauth Token.' + (!empty(response.errors) && !empty(response.errors[0].message) ? response.errors[0].message : ''));

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
@@ -70,10 +70,10 @@ var clearBillingInformationInBasket = function (basket) {
  * @returns {void} - no return data
  */
 exports.clearBoltSessionData = function () {
-    delete session.privacy.boltOauthToken;
-    delete session.privacy.boltRefreshToken;
-    delete session.privacy.boltRefreshTokenScope;
-    delete session.privacy.boltOauthTokenExpire;
+    delete session.custom.boltOauthToken;
+    delete session.custom.boltRefreshToken;
+    delete session.custom.boltRefreshTokenScope;
+    delete session.custom.boltOauthTokenExpire;
 };
 
 /**
@@ -94,7 +94,7 @@ exports.clearShopperDataInBasket = function () {
  * @returns {boolean} - if bolt user returns true otherwise false
  */
 exports.loginAsBoltUser = function () {
-    return session.privacy.boltOauthToken !== null;
+    return session.custom.boltOauthToken !== null;
 };
 
 /*


### PR DESCRIPTION
Move bolt data from `session.privacy` to `session.custom` to let them live longer due to the constraint that privacy data will be cleared after 30 mins, which is too short. Now they can live 6 hrs.