### PR TITLE
setting timeout of bolt.http to 30s

### DIFF
--- a/metadata/bolt-meta-import-embedded/services.xml
+++ b/metadata/bolt-meta-import-embedded/services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns="http://www.demandware.com/xml/impex/services/2014-09-26">
   <service-profile service-profile-id="bolt.http.profile">
-    <timeout-millis>3000</timeout-millis>
+    <timeout-millis>30000</timeout-millis>
     <rate-limit-enabled>false</rate-limit-enabled>
     <rate-limit-calls>0</rate-limit-calls>
     <rate-limit-millis>0</rate-limit-millis>


### PR DESCRIPTION
asana: https://app.asana.com/0/1201931884901947/1202684714083873 

The time out of bolt.http service used to be 3s which is too low considering the OCAPI round trips + calls we made to auth providers & payment processors. Making it 30s to avoid most of timeout errors 