### PR TITLE
Add logic to sent service unavailable reason out to the caller function.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
@@ -95,6 +95,14 @@ exports.restAPIClient = function (method, endPoint, request, requestContentType,
 
     log.error('Error on Service execution: ' + result);
 
+    if (result && result.status === HttpResult.SERVICE_UNAVAILABLE) {
+        return {
+            status: HttpResult.ERROR,
+            errors: [new Error(result.unavailableReason)],
+            result: null
+        };
+    }
+
     if (result.errorMessage) {
         try {
             var responseError = JSON.parse(result.errorMessage);


### PR DESCRIPTION
Add logic to include service unavailable reason like `time out`, `circuit broken`, `rate limited` in the return object so the caller function can get the information and use it for the following logic.

![Screen Shot 2022-09-28 at 4 13 05 PM](https://user-images.githubusercontent.com/93539162/192884105-7b4b8c68-6a26-49bf-918d-988519fbe3d2.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202965974048832