### PR TITLE
Hide create checkout box if bolt email is detected.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
@@ -94,6 +94,10 @@ exports.checkAccountAndFetchDetail = function () {
     const emailInput = $('#email-guest');
     const customerEmail = emailInput.val();
     const checkBoltAccountUrl = $('.check-bolt-account-exist').val() + '=' + encodeURIComponent(customerEmail);
+    const $accountCheckbox = $('#acct-checkbox');
+    if ($accountCheckbox) {
+        $accountCheckbox.show();
+    }
     $.ajax({
         url: checkBoltAccountUrl,
         method: 'GET',
@@ -101,6 +105,9 @@ exports.checkAccountAndFetchDetail = function () {
             if (data !== null) {
                 if (data.has_bolt_account) {
                     login(customerEmail);
+                    if ($accountCheckbox) {
+                        $('#acct-checkbox').hide();
+                    }
                 } else {
                     $('.submit-customer').removeAttr('disabled'); // enable checkout button for non Bolt shopper
                 }


### PR DESCRIPTION
Asana task: https://app.asana.com/0/1200879031426307/1203048321036598/f
Point 2: _If bolt account already exists, the 'create bolt account' checkbox should not be displayed_

Bolt account not exist:


https://user-images.githubusercontent.com/93539162/193627639-21f40f0d-3dbf-4524-b690-ae3327f4a522.mov



Bolt account already exists:


https://user-images.githubusercontent.com/93539162/193627656-30eabb89-7b21-4ad5-91ad-e20d123b21d3.mov

