### PR TITLE
Add publishable key to boltEmbed script injection

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/templates/default/checkout/boltEmbed.isml
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/templates/default/checkout/boltEmbed.isml
@@ -5,7 +5,8 @@
     <input type="hidden" class="bolt-publishable-key" value="${pdict.config.boltMultiPublishableKey}" />
     <input type="hidden" class="bolt-locale" value="${pdict.locale}" />
     <input type="hidden" class="bolt-is-shopper-logged-in" value="${pdict.isBoltShopperLoggedIn}" />
-    <script id="bolt-embedded" type="text/javascript" src="${pdict.config.boltCdnUrl}/embed.js" data-publishable-key="${pdict.config.boltMultiPublishableKey}" defer> </script>
+    <script id="bolt-embed" type="text/javascript" src="${pdict.config.boltCdnUrl}/embed.js"
+        data-publishable-key="${pdict.config.boltMultiPublishableKey}" defer> </script>
     <isscript>
         var assets = require('*/cartridge/scripts/assets.js');
         assets.addJs('/js/tokenization.js');


### PR DESCRIPTION
Adding publishable key to boltEmbed script injection to meet analytics event requirement
context: https://boltpay.slack.com/archives/C026U480KSN/p1664904619277459?thread_ts=1664828801.950469&cid=C026U480KSN

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203171355321227