### PR TITLE
Fix gift card amount issue.

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -13,6 +13,7 @@ var collections = require('*/cartridge/scripts/util/collections');
 var boltHttpUtils = require('~/cartridge/scripts/services/httpUtils');
 var constants = require('~/cartridge/scripts/util/constants');
 var boltAccountUtils = require('~/cartridge/scripts/util/boltAccountUtils');
+var boltPaymentUtils = require('~/cartridge/scripts/util/boltPaymentUtils');
 var logUtils = require('~/cartridge/scripts/util/boltLogUtils');
 var log = logUtils.getLogger('Auth');
 
@@ -49,9 +50,8 @@ function handle(
         collections.forEach(paymentInstruments, function (item) {
             currentBasket.removePaymentInstrument(item);
         });
-        var nonGCTotal = currentBasket.totalGrossPrice.subtract(
-            currentBasket.giftCertificateTotalGrossPrice
-        );
+        var gcTotal = boltPaymentUtils.getGiftCertificatesAmount(currentBasket);
+        var nonGCTotal = currentBasket.totalGrossPrice.subtract(gcTotal);
         paymentInstrument = currentBasket.createPaymentInstrument(paymentMethodID, nonGCTotal);
     });
 

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPaymentUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPaymentUtils.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// API Includes
+var Money = require('dw/value/Money');
+/**
+ * get amount from gift certificate payment instruments
+ * @param {dw.order.LineItemCtnr} lineItemCtnr Order object
+ * @return {dw.value.Money} New Amount value
+ */
+exports.getGiftCertificatesAmount = function (lineItemCtnr) {
+    var amount = new Money(0, lineItemCtnr.getCurrencyCode());
+    var paymentInstruments = lineItemCtnr.getGiftCertificatePaymentInstruments();
+
+    var iterator = paymentInstruments.iterator();
+    var paymentInstrument = null;
+
+    while (iterator.hasNext()) {
+        paymentInstrument = iterator.next();
+        amount = amount.add(paymentInstrument.getPaymentTransaction().getAmount());
+    }
+
+    return amount;
+};

--- a/test/mocks/bolt/boltPaymentUtils.js
+++ b/test/mocks/bolt/boltPaymentUtils.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function getGiftCertificatesAmount() {
+    return {
+        value : 1.0,
+        currencyCode : 'USD'
+    };
+}
+module.exports = {
+    getGiftCertificatesAmount: getGiftCertificatesAmount
+};

--- a/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
+++ b/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
@@ -49,7 +49,8 @@ describe('bolt pay payment processor', function () {
         },
         '~/cartridge/scripts/util/constants':require('../../../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants'),
         '~/cartridge/scripts/util/boltAccountUtils': boltAccountUtilsMock,
-        '~/cartridge/scripts/util/boltLogUtils':require('../../../../../../mocks/bolt/boltLogUtils')
+        '~/cartridge/scripts/util/boltLogUtils':require('../../../../../../mocks/bolt/boltLogUtils'),
+        '~/cartridge/scripts/util/boltPaymentUtils':require('../../../../../../mocks/bolt/boltPaymentUtils')
     };
 
     beforeEach(function () {


### PR DESCRIPTION
Issue:
Qi found an issue in embedded cartridge regarding gift card amount issue.
[Here](https://github.com/BoltApp/bolt-demandware-embedded/blob/master/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js#L52) the logic is supposed to get bolt payment amount by using order tota subtracting gift card amount. However, the SFCC method basket.giftCertificateTotalGrossPrice is a method to get the total price for gift card item(not gift card payment). Hence the method used here is wrong.

Test:
Tested locally on zzgv-018 with my own code version "justin_embedded".
1. Hardcoded a gift card payment and the code runs as expected in debug mode
2. Do a normal non gift card checkout and the order is placed successfully with correct bolt transaction amount(Test order: 00005702)
3. Passed Unit test
![Screen Shot 2023-02-06 at 11 36 56 AM](https://user-images.githubusercontent.com/93539162/217033786-5d039e65-1b5d-4ea8-8493-fc7b609d71e7.png)
![Screen Shot 2023-02-06 at 11 40 18 AM](https://user-images.githubusercontent.com/93539162/217033800-867157e7-85b0-4c9e-8e8f-aef61e2e15b6.png)
![Screen Shot 2023-02-06 at 11 51 24 AM](https://user-images.githubusercontent.com/93539162/217033821-3197ca2e-660e-497c-9eb0-38c41235477f.png)

Asana task: https://app.asana.com/0/1201931884901947/1203906703882450/f



