### PR TITLE
Properly Send OAuth Token SFCC Embedded

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -14,6 +14,7 @@ var boltHttpUtils = require('~/cartridge/scripts/services/httpUtils');
 var constants = require('~/cartridge/scripts/util/constants');
 var boltAccountUtils = require('~/cartridge/scripts/util/boltAccountUtils');
 var boltPaymentUtils = require('~/cartridge/scripts/util/boltPaymentUtils');
+var oAuth = require('~/cartridge/scripts/services/oAuth');
 var logUtils = require('~/cartridge/scripts/util/boltLogUtils');
 var log = logUtils.getLogger('Auth');
 
@@ -124,12 +125,20 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
         log.error(authRequestObj.errorMsg);
     }
 
+    // only attach oauth token if it is available and the user has not logged out
+    var boltOAuthToken = oAuth.getOAuthToken();
+    var bearerToken = null
+    if (!empty(boltOAuthToken)) {
+        bearerToken = 'Bearer '.concat(boltOAuthToken);
+    }
+
     // send auth call
     var response = boltHttpUtils.restAPIClient(
         constants.HTTP_METHOD_POST,
         constants.AUTH_CARD_URL,
         JSON.stringify(authRequestObj.authRequest),
-        constants.CONTENT_TYPE_JSON
+        constants.CONTENT_TYPE_JSON,
+        bearerToken
     );
     if (response.status && response.status === HttpResult.ERROR) {
         var errorMessage = !empty(response.errors) && !empty(response.errors[0].message)

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -127,7 +127,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
 
     // only attach oauth token if it is available and the user has not logged out
     var boltOAuthToken = oAuth.getOAuthToken();
-    var bearerToken = null;
+    var bearerToken;
     if (!empty(boltOAuthToken)) {
         bearerToken = 'Bearer '.concat(boltOAuthToken);
     }

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -128,7 +128,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
     // only attach oauth token if it is available and the user has not logged out
     var boltOAuthToken = oAuth.getOAuthToken();
     var bearerToken;
-    if (!empty(boltOAuthToken)) {
+    if (!empty(boltOAuthToken) && !sessionLogoutCookieSet()) {
         bearerToken = 'Bearer '.concat(boltOAuthToken);
     }
 
@@ -274,6 +274,22 @@ function getDwsidCookie() {
     }
 
     return '';
+}
+
+/**
+ * sessionLogoutCookieSet returns true if the bolt_sfcc_session_logout is set
+ * @return {boolean} true if the cookie is set otherwise false
+ */
+function sessionLogoutCookieSet() {
+    var cookies = request.getHttpCookies();
+
+    for (var i = 0; i < cookies.cookieCount; i++) { // eslint-disable-line no-plusplus
+        if (cookies[i].name === 'bolt_sfcc_session_logout') {
+            return cookies[i].value == 'true' ? true : false;
+        }
+    }
+
+    return false;
 }
 
 module.exports = {

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -11,10 +11,10 @@ var HttpResult = require('dw/svc/Result');
 // Script includes
 var collections = require('*/cartridge/scripts/util/collections');
 var boltHttpUtils = require('~/cartridge/scripts/services/httpUtils');
+var oAuth = require('~/cartridge/scripts/services/oAuth');
 var constants = require('~/cartridge/scripts/util/constants');
 var boltAccountUtils = require('~/cartridge/scripts/util/boltAccountUtils');
 var boltPaymentUtils = require('~/cartridge/scripts/util/boltPaymentUtils');
-var oAuth = require('~/cartridge/scripts/services/oAuth');
 var logUtils = require('~/cartridge/scripts/util/boltLogUtils');
 var log = logUtils.getLogger('Auth');
 
@@ -127,7 +127,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
 
     // only attach oauth token if it is available and the user has not logged out
     var boltOAuthToken = oAuth.getOAuthToken();
-    var bearerToken = null
+    var bearerToken = null;
     if (!empty(boltOAuthToken)) {
         bearerToken = 'Bearer '.concat(boltOAuthToken);
     }

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -285,7 +285,7 @@ function sessionLogoutCookieSet() {
 
     for (var i = 0; i < cookies.cookieCount; i++) { // eslint-disable-line no-plusplus
         if (cookies[i].name === 'bolt_sfcc_session_logout') {
-            return cookies[i].value == 'true' ? true : false;
+            return cookies[i].value === 'true' ? true : false;
         }
     }
 

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -285,7 +285,7 @@ function sessionLogoutCookieSet() {
 
     for (var i = 0; i < cookies.cookieCount; i++) { // eslint-disable-line no-plusplus
         if (cookies[i].name === 'bolt_sfcc_session_logout') {
-            return cookies[i].value === 'true' ? true : false;
+            return cookies[i].value === 'true';
         }
     }
 

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
@@ -44,7 +44,7 @@ exports.restAPIClient = function (
             service.addHeader('X-Nonce', new Date().getTime());
             service.addHeader('X-Bolt-Source-Name', constants.BOLT_SOURCE_NAME);
             service.addHeader('X-Bolt-Source-Version', constants.BOLT_CARTRIDGE_VERSION);
-            if (authenticationHeader) {
+            if (authenticationHeader && authenticationHeader != null) {
                 service.addHeader('Authorization', authenticationHeader);
             }
             return args.request;

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/httpUtils.js
@@ -44,7 +44,7 @@ exports.restAPIClient = function (
             service.addHeader('X-Nonce', new Date().getTime());
             service.addHeader('X-Bolt-Source-Name', constants.BOLT_SOURCE_NAME);
             service.addHeader('X-Bolt-Source-Version', constants.BOLT_CARTRIDGE_VERSION);
-            if (authenticationHeader && authenticationHeader != null) {
+            if (authenticationHeader) {
                 service.addHeader('Authorization', authenticationHeader);
             }
             return args.request;

--- a/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
+++ b/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
@@ -30,6 +30,7 @@ describe('bolt pay payment processor', function () {
     var boltPay;
     var boltPayFilePath = '../../../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay';
     var responseMock = {};
+    var oAuthTokenMock;
     var boltAccountUtilsMock = require('../../../../../../mocks/bolt/boltAccountUtils.js');
     boltAccountUtilsMock.loginAsBoltUser = loginAsBoltUserStub;
     var requiredModulesMock = {

--- a/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
+++ b/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
@@ -47,6 +47,11 @@ describe('bolt pay payment processor', function () {
                 return responseMock;
             }
         },
+        '~/cartridge/scripts/services/oAuth' : {
+            getOAuthToken() {
+                return oAuthTokenMock;
+            }
+        },
         '~/cartridge/scripts/util/constants':require('../../../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants'),
         '~/cartridge/scripts/util/boltAccountUtils': boltAccountUtilsMock,
         '~/cartridge/scripts/util/boltLogUtils':require('../../../../../../mocks/bolt/boltLogUtils'),


### PR DESCRIPTION
Although we aren't trying to heavily invest in modifications to embedded cartridge right now this is a necessary one.

Other integrations pass the OAuth token as part of authorize when the user is logged-in. Casper will need this change to be able to get client IP to adyen for their auths.