### PR TITLE
Remove extra call to save payment method

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -107,16 +107,6 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
         paymentInstrument.paymentTransaction.setPaymentProcessor(paymentProcessor);
     });
     var order = OrderMgr.getOrder(orderNumber);
-    // save card to bolt account
-    // if save card is success, use the new credit card id for authorization
-    if (boltAccountUtils.loginAsBoltUser() && !empty(paymentInstrument.getCreditCardToken())) {
-        var saveCardResult = boltAccountUtils.saveCardToBolt(order, paymentInstrument);
-        if (saveCardResult.success) {
-            Transaction.wrap(function () {
-                paymentInstrument.custom.boltPaymentMethodId = saveCardResult.newPaymentMethodID;
-            });
-        }
-    }
 
     // build auth request
     var authRequestObj = boltPayAuthRequestBuilder.build(order, paymentInstrument);

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPayAuthRequestBuilder.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPayAuthRequestBuilder.js
@@ -120,7 +120,10 @@ function buildCartField(order, paymentInstrument) {
         in_store_cart_shipments: [],
         items: buildCarItemField(order),
         discounts: buildDiscountsField(order),
-        shipments: buildShipmentsField(order)
+        shipments: buildShipmentsField(order),
+        metadata: {
+            SFCCSessionID: getDwsidCookie()
+        }
     };
     return cart;
 }
@@ -387,4 +390,20 @@ function getProductTotalPriceInCents(productLineItem) {
         totalPrice += optionProductLineItemAmount;
     }
     return Math.round(totalPrice * 100);
+}
+
+/**
+ * getDwsidCookie returns DW Session ID from cookie
+ * @return {string} DW Session ID
+ */
+function getDwsidCookie() {
+    var cookies = request.getHttpCookies();
+
+    for (var i = 0; i < cookies.cookieCount; i++) { // eslint-disable-line no-plusplus
+        if (cookies[i].name === 'dwsid') {
+            return cookies[i].value;
+        }
+    }
+
+    return '';
 }

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPayAuthRequestBuilder.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltPayAuthRequestBuilder.js
@@ -121,6 +121,9 @@ function buildCartField(order, paymentInstrument) {
         items: buildCarItemField(order),
         discounts: buildDiscountsField(order),
         shipments: buildShipmentsField(order),
+        // metadata field is not used unless merchant is using old OCAPI
+        // flow with "sfcc_embedded_skip_ocapi_fetch_order" gate
+        // TODO (Alex P): Update this comment once gate removed
         metadata: {
             SFCCSessionID: getDwsidCookie()
         }


### PR DESCRIPTION
2 changes in this PR:
1. Firstly, we're removing the unnecessary call to save a new payment method to Bolt account. Confirmed that when a shopper is logged in, regardless of the value of `saved` value in the authorization call request, the payment method is saved to their account.
2. Re-added metadata in cart body. This allows merchants that want to switch back to OCAPI flow for creating orders.