### PR TITLE
Remove unneeded call to save address

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -122,7 +122,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
         bearerToken = 'Bearer '.concat(boltOAuthToken);
     }
 
-    // send auth call
+    // Send auth call, note: saves both new address and new payment method.
     var response = boltHttpUtils.restAPIClient(
         constants.HTTP_METHOD_POST,
         constants.AUTH_CARD_URL,
@@ -146,11 +146,6 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
         order.custom.boltTransactionReference = response.result.transaction && response.result.transaction.reference ? response.result.transaction.reference : '';
         paymentInstrument.getPaymentTransaction().setTransactionID(orderNumber);
     });
-
-    // save shipping address to bolt account
-    if (boltAccountUtils.loginAsBoltUser()) {
-        boltAccountUtils.saveAddressToBolt(order);
-    }
 
     return { error: false };
 }

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/boltAccountUtils.js
@@ -179,57 +179,6 @@ exports.saveCardToBolt = function (order, paymentInstrument) {
 };
 
 /**
- * Save new address to Bolt or update existing Bolt address
- * @param {dw.order.Order} order - SFCC order object
- * @returns {void} - no return data
- */
-exports.saveAddressToBolt = function (order) {
-    try {
-        var shippingAddress = order.getDefaultShipment().getShippingAddress();
-        var errorMsg;
-        // add bolt address id to endpoint if shopper is updating existing address
-        var addressUrl = !empty(shippingAddress.custom.boltAddressId) ? (constants.SHOPPER_ADDRESS_URL + '/' + shippingAddress.custom.boltAddressId) : constants.SHOPPER_ADDRESS_URL;
-        var isGift = order.getDefaultShipment().isGift();
-
-        var request = {
-            street_address1: shippingAddress.address1 || '',
-            street_address2: shippingAddress.address2 || '',
-            locality: shippingAddress.city || '',
-            region: shippingAddress.stateCode || '',
-            postal_code: shippingAddress.postalCode || '',
-            country_code: shippingAddress.countryCode.value || '',
-            first_name: shippingAddress.firstName || '',
-            last_name: shippingAddress.lastName || '',
-            phone: shippingAddress.phone || '',
-            default: !isGift
-        };
-
-        var boltOAuthToken = oAuth.getOAuthToken();
-        if (empty(boltOAuthToken)) {
-            errorMsg = 'Bolt OAuth Token is missing';
-            log.error(errorMsg);
-            return;
-        }
-        var bearerToken = 'Bearer '.concat(boltOAuthToken);
-
-        // send save address request to Bolt
-        var response = boltHttpUtils.restAPIClient(
-            constants.HTTP_METHOD_POST,
-            addressUrl,
-            JSON.stringify(request),
-            constants.CONTENT_TYPE_JSON,
-            bearerToken
-        );
-        errorMsg = Resource.msg('error.save.address', 'bolt', null);
-        if (response.status && response.status === HttpResult.ERROR) {
-            log.error(errorMsg + (!empty(response.errors) && !empty(response.errors[0].message) ? response.errors[0].message : ''));
-        }
-        log.info('address successfully saved to bolt');
-    } catch (e) {
-        log.error(e.message);
-    }
-};
-/**
  * Get bolt payment data which is stored in SFCC basket
  * @param {dw.order.Basket} basket - the SFCC basket
  * @param {string} selectedBoltPaymentID - selected Bolt Payment ID

--- a/test/mocks/bolt/boltAccountUtils.js
+++ b/test/mocks/bolt/boltAccountUtils.js
@@ -20,10 +20,6 @@ function saveCardToBolt() {
     }
 }
 
-function saveAddressToBolt() {
-    
-}
-
 function isEmptyAddress(){
     return false;
 }
@@ -32,6 +28,5 @@ module.exports = {
     checkEmptyValue: checkEmptyValue,
     getBoltPayment: getBoltPayment,
     saveCardToBolt: saveCardToBolt,
-    saveAddressToBolt: saveAddressToBolt,
     isEmptyAddress: isEmptyAddress
 };

--- a/test/unit/int_bolt_embedded_sfra/script/util/boltAccountUtils.js
+++ b/test/unit/int_bolt_embedded_sfra/script/util/boltAccountUtils.js
@@ -299,42 +299,4 @@ describe('boltAccountUtils', function () {
         });
     });
 
-    describe('saveAddressToBolt', function () {
-        var order;
-        beforeEach(function () {
-            order = require('../../../../mocks/order');
-            oAuthTokenMock = 'oAuthToken';
-            logErrorSpy.resetHistory();
-        });
-
-        it('should trigger log.error function when OAuth token is missing', function () {
-            oAuthTokenMock = null;
-            boltAccountUtils.saveAddressToBolt(order);
-            expect(logErrorSpy.callCount).to.be.equal(1);
-        });
-
-        it('should save address to bolt shopper account and not trigger log.error function', function () {
-            responseMock = {
-                status : 0
-            };
-            boltAccountUtils.saveAddressToBolt(order);
-            expect(logErrorSpy.callCount).to.be.equal(0);
-        });
-
-        it('should trigger log.error function when save address response returns error', function () {
-            responseMock = {
-                status : 1
-            };
-            boltAccountUtils.saveAddressToBolt(order);
-            expect(logErrorSpy.callCount).to.be.equal(1);
-        });
-
-        it('should trigger log.error function when exception occurs', function () {
-            order.getDefaultShipment = function (){
-                throw new Error('Not able to get default shipment');
-            };
-            boltAccountUtils.saveAddressToBolt(order);
-            expect(logErrorSpy.callCount).to.be.equal(1);
-        });
-    });
 });


### PR DESCRIPTION
Removing unnecessary call to save address to Bolt account. We save address in our auth call. Also removing no longer needed related functions and tests.

Tested locally that functionality for saving addresses and payments is not affected during logged in checkout.

Asana: https://app.asana.com/0/1201931884901947/1204816113317289/f