### PR TITLE
Create SFCC Platform Account for Guest

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -300,23 +300,21 @@ function sessionLogoutCookieSet() {
 }
 
 /**
- * If SSO is enabled and Bolt account creation succeed, 
- * create a new external authenticated account or external profile for existing account
- * @param {Object} response 
+ * If SSO is enabled and Bolt account creation succeed, create a new external authenticated account or external profile for existing account
+ * @param {Object} response - Auth response
  * @param {dw.order.Order} order - SFCC order object
- * @returns 
  */
 function createSSOPlatformAccount(response, order) {
     var isBoltAccountCreated = response.result && response.result.did_create_bolt_account ? response.result.did_create_bolt_account : false;
     var platformAccountID = response.result && response.result.platform_account_id ? response.result.platform_account_id : '';
-    
+
     if (!isBoltAccountCreated) {
-        log.warn("Bolt account is not created, skip platform account creation.");
+        log.warn('Bolt account is not created, skip platform account creation.');
         return;
     }
 
     if (empty(platformAccountID)) {
-        log.warn("Missing platform account ID from Bolt, skip platform account creation.");
+        log.warn('Missing platform account ID from Bolt, skip platform account creation.');
         return;
     }
 
@@ -333,8 +331,6 @@ function createSSOPlatformAccount(response, order) {
     } else {
         log.info('Successfully created a new SFCC account or new external profile.');
     }
-
-    return;
 }
 
 module.exports = {

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -166,12 +166,11 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
     // create platform account for SSO
     var createBoltAccount = paymentInstrument.custom.boltCreateAccount;
     var isSSOEnabled = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
-    var isBoltAccountCreated = response.result ? response.result.did_create_bolt_account : false;
-    var platformAccID = response.result ? response.result.platform_account_id : '';
-    var emailverified = response.result && response.result.email_verified;
-    if (isSSOEnabled && createBoltAccount && isBoltAccountCreated) {
+    var isBoltAccountCreated = response.result && response.result.did_create_bolt_account? response.result.did_create_bolt_account : false;
+    var platformAccountID = response.result && response.result.platform_account_id ? response.result.platform_account_id : '';
+    if (isSSOEnabled && createBoltAccount && isBoltAccountCreated && platformAccountID) {
         var externalProfile = {
-            sub: response.result ? response.result.platform_account_id : '',
+            sub: platformAccountID,
             email_verified: response.result && response.result.email_verified,
             email: order.getCustomerEmail(),
             first_name: order.getBillingAddress().getFirstName(),

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay.js
@@ -166,7 +166,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
     // create platform account for SSO
     var createBoltAccount = paymentInstrument.custom.boltCreateAccount;
     var isSSOEnabled = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
-    var isBoltAccountCreated = response.result && response.result.did_create_bolt_account? response.result.did_create_bolt_account : false;
+    var isBoltAccountCreated = response.result && response.result.did_create_bolt_account ? response.result.did_create_bolt_account : false;
     var platformAccountID = response.result && response.result.platform_account_id ? response.result.platform_account_id : '';
     if (isSSOEnabled && createBoltAccount && isBoltAccountCreated && platformAccountID) {
         var externalProfile = {
@@ -176,8 +176,7 @@ function authorize(orderNumber, paymentInstrument, paymentProcessor) {
             first_name: order.getBillingAddress().getFirstName(),
             last_name: order.getBillingAddress().getLastName()
         };
-
-        var res = oauthUtils.createPlatformAccount(externalProfile, {value: orderNumber}, {value: order.orderToken});
+        var res = oauthUtils.createPlatformAccount(externalProfile, { value: orderNumber }, { value: order.orderToken });
         if (res.error) {
             log.info('Error occured when creating platform account.');
         }

--- a/test/mocks/dw/system/Site.js
+++ b/test/mocks/dw/system/Site.js
@@ -17,6 +17,8 @@ function getCurrent() {
                     return boltMerchantDivisionID;
                 case 'boltEnvironment':
                     return boltEnvironment;
+                case 'boltEnableSSO':
+                    return true;
                 default:
                     return 'some_custom_preference_value';
             }

--- a/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
+++ b/test/unit/int_bolt_embedded_sfra/script/hooks/payment/processor/bolt_pay.js
@@ -31,6 +31,7 @@ describe('bolt pay payment processor', function () {
     var boltPayFilePath = '../../../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/hooks/payment/processor/bolt_pay';
     var responseMock = {};
     var oAuthTokenMock;
+    var platformAccountMock;
     var boltAccountUtilsMock = require('../../../../../../mocks/bolt/boltAccountUtils.js');
     boltAccountUtilsMock.loginAsBoltUser = loginAsBoltUserStub;
     var requiredModulesMock = {
@@ -56,7 +57,12 @@ describe('bolt pay payment processor', function () {
         '~/cartridge/scripts/util/constants':require('../../../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants'),
         '~/cartridge/scripts/util/boltAccountUtils': boltAccountUtilsMock,
         '~/cartridge/scripts/util/boltLogUtils':require('../../../../../../mocks/bolt/boltLogUtils'),
-        '~/cartridge/scripts/util/boltPaymentUtils':require('../../../../../../mocks/bolt/boltPaymentUtils')
+        '~/cartridge/scripts/util/boltPaymentUtils':require('../../../../../../mocks/bolt/boltPaymentUtils'),
+        '~/cartridge/scripts/util/oauthUtils': {
+            createPlatformAccount() {
+                return platformAccountMock;
+            }
+        }
     };
 
     beforeEach(function () {
@@ -144,5 +150,50 @@ describe('bolt pay payment processor', function () {
             expect(res.error).to.be.false;
         });
 
+        it('create platform account successfully ', function () {
+            responseMock = {
+                status : 0,
+                errors: [],
+                result: {
+                    did_create_bolt_account: true,
+                    platform_account_id: "123-456-789"
+                }
+            };
+            var customerProfile = {
+                customerNo: "10000",
+                email: "test@bolt.com",
+                firstName: "firstName",
+                lastName: "lastName"
+            };        
+            platformAccountMock = {
+                profile: customerProfile,
+                isRegistration: true
+            };
+            paymentInstrument.custom.boltCreateAccount = true;
+            var orderNo = '123456789';
+            var res = boltPay.Authorize(orderNo, paymentInstrument, 'BOLT_PAY');
+            expect(res.error).to.be.false;
+        });
+
+        it('should not return error if create platform account failed', function () {
+            responseMock = {
+                status : 0,
+                errors: [],
+                result: {
+                    did_create_bolt_account: true,
+                    platform_account_id: "123-456-789"
+                }
+            };
+            platformAccountMock = {
+                error: {
+                    status: 'failure',
+                    message: 'error message'
+                }
+            }
+            paymentInstrument.custom.boltCreateAccount = true;
+            var orderNo = '123456789';
+            var res = boltPay.Authorize(orderNo, paymentInstrument, 'BOLT_PAY');
+            expect(res.error).to.be.false;
+        });
     });
 });


### PR DESCRIPTION
If shopper creates account during checkout and Bolt account is created successfully, we create a platform account using Bolt returned platform account ID, or create an external profile.