### PR TITLE
Fix Order Confirmation Redirect

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Order.js
@@ -1,0 +1,104 @@
+'use strict';
+var server = require('server');
+var Order = module.superModule;
+server.extend(Order);
+
+var Resource = require('dw/web/Resource');
+var URLUtils = require('dw/web/URLUtils');
+var Site = require('dw/system/Site');
+var OrderMgr = require('dw/order/OrderMgr');
+var Locale = require('dw/util/Locale');
+
+var csrfProtection = require('*/cartridge/scripts/middleware/csrf');
+var userLoggedIn = require('*/cartridge/scripts/middleware/userLoggedIn');
+var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
+var reportingUrlsHelper = require('*/cartridge/scripts/reportingUrls');
+var OrderModel = require('*/cartridge/models/order');
+
+/**
+ * Order-Confirm : This endpoint is invoked when the shopper's Order is Placed and Confirmed
+ * @name Base/Order-Confirm
+ * @function
+ * @memberof Order
+ * @param {middleware} - consentTracking.consent
+ * @param {middleware} - server.middleware.https
+ * @param {middleware} - csrfProtection.generateToken
+ * @param {querystringparameter} - ID - Order ID
+ * @param {querystringparameter} - token - token associated with the order
+ * @param {category} - sensitive
+ * @param {serverfunction} - get
+ */
+server.replace(
+    'Confirm',
+    consentTracking.consent,
+    server.middleware.https,
+    csrfProtection.generateToken,
+    function (req, res, next) {
+        var order;
+        if (!req.form.orderToken || !req.form.orderID) {
+            res.render('/error', {
+                message: Resource.msg('error.confirmation.error', 'confirmation', null)
+            });
+
+            return next();
+        }
+
+        order = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
+
+        // This is where different from the base cartridge, skip order customer check for SSO.
+        // If shopper check the Bolt checkbox to create an account during checkout, we set the order to the new created account but not login,
+        // so the order customer id is different from the guest customer ID in the original request.
+        var boltEnableSSO = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
+        var skipCustomerCheck = boltEnableSSO && order && order.custom.isNewCustomerCreated;
+        if (!order || (!skipCustomerCheck && order.customer.ID !== req.currentCustomer.raw.ID))
+        {
+            res.render('/error', {
+                message: Resource.msg('error.confirmation.error', 'confirmation', null)
+            });
+
+            return next();
+        }
+        var lastOrderID = Object.prototype.hasOwnProperty.call(req.session.raw.custom, 'orderID') ? req.session.raw.custom.orderID : null;
+        if (lastOrderID === req.querystring.ID) {
+            res.redirect(URLUtils.url('Home-Show'));
+            return next();
+        }
+
+        var config = {
+            numberOfLineItems: '*'
+        };
+
+        var currentLocale = Locale.getLocale(req.locale.id);
+
+        var orderModel = new OrderModel(
+            order,
+            { config: config, countryCode: currentLocale.country, containerView: 'order' }
+        );
+        var passwordForm;
+
+        var reportingURLs = reportingUrlsHelper.getOrderReportingURLs(order);
+
+        if (!req.currentCustomer.profile) {
+            passwordForm = server.forms.getForm('newPasswords');
+            passwordForm.clear();
+            res.render('checkout/confirmation/confirmation', {
+                order: orderModel,
+                returningCustomer: false,
+                passwordForm: passwordForm,
+                reportingURLs: reportingURLs,
+                orderUUID: order.getUUID()
+            });
+        } else {
+            res.render('checkout/confirmation/confirmation', {
+                order: orderModel,
+                returningCustomer: true,
+                reportingURLs: reportingURLs,
+                orderUUID: order.getUUID()
+            });
+        }
+        req.session.raw.custom.orderID = req.querystring.ID; // eslint-disable-line no-param-reassign
+        return next();
+    }
+);
+
+module.exports = server.exports();

--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Order.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var server = require('server');
 var Order = module.superModule;
 server.extend(Order);
@@ -10,7 +11,6 @@ var OrderMgr = require('dw/order/OrderMgr');
 var Locale = require('dw/util/Locale');
 
 var csrfProtection = require('*/cartridge/scripts/middleware/csrf');
-var userLoggedIn = require('*/cartridge/scripts/middleware/userLoggedIn');
 var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
 var reportingUrlsHelper = require('*/cartridge/scripts/reportingUrls');
 var OrderModel = require('*/cartridge/models/order');
@@ -50,8 +50,7 @@ server.replace(
         // so the order customer id is different from the guest customer ID in the original request.
         var boltEnableSSO = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
         var skipCustomerCheck = boltEnableSSO && order && order.custom.isNewCustomerCreated;
-        if (!order || (!skipCustomerCheck && order.customer.ID !== req.currentCustomer.raw.ID))
-        {
+        if (!order || (!skipCustomerCheck && order.customer.ID !== req.currentCustomer.raw.ID)) {
             res.render('/error', {
                 message: Resource.msg('error.confirmation.error', 'confirmation', null)
             });

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/oauthUtils.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/oauthUtils.js
@@ -170,6 +170,7 @@ function createPlatformAccount(externalProfile, orderId, orderToken) {
                     var order = OrderMgr.getOrder(orderId.value, orderToken.value);
                     if (order && order.getCustomerEmail() === externalProfile.email) {
                         order.setCustomer(newCustomer);
+                        order.custom.isNewCustomerCreated = true;
                     }
                 }
             });

--- a/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
+++ b/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
@@ -165,6 +165,13 @@
         <externally-managed-flag>false</externally-managed-flag>
         <min-length>0</min-length>
       </attribute-definition>
+      <attribute-definition attribute-id="isNewCustomerCreated">
+        <display-name xml:lang="x-default">New Customer Created</display-name>
+        <description xml:lang="x-default">new customer account created during checkout and order reassigned</description>
+        <type>boolean</type>
+        <mandatory-flag>false</mandatory-flag>
+        <externally-managed-flag>false</externally-managed-flag>
+      </attribute-definition>
     </custom-attribute-definitions>
       <group-definitions>
         <attribute-group group-id="Bolt Attributes">


### PR DESCRIPTION
If SSO enabled and shopper creates an account during checkout, we also create a new platform account if doesn't have, and assign this order to the new created account. To make order confirmation page redirect work, skip the customer check for this specific use case.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205094102926167