### PR TITLE
Bugfix: Max length exceed on basket.custom property

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/services/account.js
@@ -174,7 +174,8 @@ function addPaymentMethodInfoToBasket(basket, boltPaymentMethods) {
     }
     // store all payment methods in the basket so that it can be later chosen by the customer
     Transaction.wrap(function () {
-        basket.getCustom().boltPaymentMethods = JSON.stringify(boltPaymentMethods);
+        // The maximum byte length of basket.custom property is 4000, so we only get the first 5 payment methods to avoid string value truncated
+        basket.getCustom().boltPaymentMethods = JSON.stringify(boltPaymentMethods.length > 5 ? boltPaymentMethods.slice(0, 5) : boltPaymentMethods);
     });
 
     var creditCardNumber = boltPaymentMethod.last4 ? constants.CC_MASKED_DIGITS + boltPaymentMethod.last4 : '';

--- a/test/mocks/dw/crypto/Encoding.js
+++ b/test/mocks/dw/crypto/Encoding.js
@@ -1,0 +1,10 @@
+var Encoding = function () { };
+
+Encoding.toHex = function (param) { return param; };
+Encoding.toURI = function (param) { return param; };
+Encoding.toBase64 = function (param) { return param; };
+Encoding.fromBase64 = function (param) { return param; };
+Encoding.fromHex = function (param) { return param; };
+Encoding.fromURI = function (param) { return param; };
+
+module.exports = Encoding;

--- a/test/mocks/dw/crypto/Mac.js
+++ b/test/mocks/dw/crypto/Mac.js
@@ -1,0 +1,5 @@
+var Mac = function () { };
+
+Mac.prototype.digest = function () { };
+
+module.exports = Mac;

--- a/test/unit/int_bolt_embedded_sfra/script/services/httpUtils.js
+++ b/test/unit/int_bolt_embedded_sfra/script/services/httpUtils.js
@@ -17,6 +17,9 @@ describe('httpUtils happy path', function () {
         'dw/svc/LocalServiceRegistry': require('../../../../mocks/dw/svc/LocalServiceRegistry'),
         'dw/svc/Result': require('../../../../mocks/dw/svc/Result'),
         'dw/system/System': require('../../../../mocks/dw/system/System'),
+        'dw/system/Site': require('../../../../mocks/dw/system/Site'),
+        'dw/crypto/Mac': require('../../../../mocks/dw/crypto/Mac'),
+        'dw/crypto/Encoding': require('../../../../mocks/dw/crypto/Encoding'),
         '~/cartridge/scripts/util/constants': require('../../../../../cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants'),
         '~/cartridge/scripts/util/boltLogUtils': require('../../../../mocks/bolt/boltLogUtils'),
         '~/cartridge/scripts/util/preferences': require('../../../../mocks/bolt/preferences.js')


### PR DESCRIPTION
The maximum byte length of `basket.custom` property is 4000, and `shopperDetails.payment_methods` could exceed that length, so the string value is truncated when converting `shopperDetails.payment_methods`  to `shopperDetails.payment_methods` , and it causes a JSON.parse exception when parsing `basket.custom.boltPaymentMethods`.

The solution is to only get the first 5 payment methods to avoid string value truncated.


https://app.asana.com/0/1201931884901947/1205211596787212/f