### PR TITLE
Update Existing SFCC Account

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
@@ -158,9 +158,10 @@ server.post('CreateCompleteAccount', function (req, res, next) {
         var httpParameterMap = request.getHttpParameterMap();
         var requestBodyString = httpParameterMap.get('requestBodyAsString') ? httpParameterMap.requestBodyAsString : null;
         var requestBody = JSON.parse(requestBodyString);
-        var boltProfile = requestBody.profile;
-        var boltAddresses = requestBody.addresses;
-        var boltPayments = requestBody.payment_methods;
+        var accountDetails = requestBody.account_details;
+        var boltProfile = accountDetails.profile;
+        var boltAddresses = accountDetails.addresses;
+        var boltPayments = accountDetails.payment_methods;
 
         if (!boltProfile) {
             return httpUtils.errorResponse('Missing profile in the request body.', 400, res, next);

--- a/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/controllers/Bolt.js
@@ -169,25 +169,40 @@ server.post('CreateCompleteAccount', function (req, res, next) {
             return httpUtils.errorResponse('Missing email in the request body profile.', 400, res, next);
         }
 
-        var platformAccountID = UUIDUtils.createUUID();
-        var newCustomer;
-        Transaction.wrap(function () {
-            newCustomer = CustomerMgr.createExternallyAuthenticatedCustomer('Bolt', platformAccountID);
-            var customerProfile = newCustomer.getProfile();
-            customerProfile.setEmail(boltProfile.email);
-            customerProfile.setFirstName(boltProfile.first_name);
-            customerProfile.setLastName(boltProfile.last_name);
-        });
+        var platformAccountID = boltProfile.platform_account_id;
+        if (!platformAccountID) {
+            platformAccountID = UUIDUtils.createUUID();
+        }
+
+        var authenticatedCustomerProfile = CustomerMgr.getExternallyAuthenticatedCustomerProfile(constants.BOLT_PROVIDER, platformAccountID);
+        var customer;
+        if (authenticatedCustomerProfile) {
+            customer = authenticatedCustomerProfile.getCustomer();
+        } else {
+            var existingCustomer = CustomerMgr.getCustomerByLogin(boltProfile.email);
+            Transaction.wrap(function () {
+                if (existingCustomer) {
+                    existingCustomer.createExternalProfile(constants.BOLT_PROVIDER, platformAccountID);
+                    customer = existingCustomer;
+                } else {
+                    customer = CustomerMgr.createExternallyAuthenticatedCustomer(constants.BOLT_PROVIDER, platformAccountID);
+                    var customerProfile = customer.getProfile();
+                    customerProfile.setEmail(boltProfile.email);
+                    customerProfile.setFirstName(boltProfile.first_name);
+                    customerProfile.setLastName(boltProfile.last_name);
+                }
+            });
+        }
 
         if (boltAddresses) {
-            var ok = boltAccountUtils.saveBoltAddress(newCustomer, boltAddresses);
+            var ok = boltAccountUtils.updateBoltAddresses(customer, boltAddresses);
             if (!ok) {
                 log.error('Failed to save Bolt addresses to SFCC account.');
             }
         }
 
         if (boltPayments) {
-            var rs = boltAccountUtils.saveBoltPayments(newCustomer, boltPayments);
+            var rs = boltAccountUtils.updateBoltPayments(customer, boltPayments);
             if (!rs) {
                 log.error('Failed to save Bolt payments to SFCC account.');
             }

--- a/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/scripts/util/constants.js
@@ -46,3 +46,8 @@ exports.CONTENT_TYPE_URL_ENCODED = 'application/x-www-form-urlencoded';
  * 4000 -> 4 seconds
  */
 exports.OAUTH_TOKEN_REFRESH_TIME = 4000;
+
+/**
+ * Embedded SSO
+ */
+exports.BOLT_PROVIDER = 'Bolt';

--- a/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
+++ b/metadata/bolt-meta-import-embedded/meta/system-objecttype-extensions.xml
@@ -180,4 +180,28 @@
       </attribute-group>
     </group-definitions>
   </type-extension>
+
+  <type-extension type-id="CustomerPaymentInstrument">
+    <custom-attribute-definitions>
+      <attribute-definition attribute-id="boltPaymentMethodId">
+          <display-name xml:lang="x-default">Bolt Payment Method ID</display-name>
+          <type>string</type>
+          <mandatory-flag>false</mandatory-flag>
+          <externally-managed-flag>false</externally-managed-flag>
+          <min-length>0</min-length>
+      </attribute-definition>
+    </custom-attribute-definitions>
+  </type-extension>
+
+  <type-extension type-id="CustomerAddress">
+    <custom-attribute-definitions>
+      <attribute-definition attribute-id="boltAddressId">
+              <display-name xml:lang="x-default">Bolt Address ID</display-name>
+              <type>string</type>
+              <mandatory-flag>false</mandatory-flag>
+              <externally-managed-flag>false</externally-managed-flag>
+              <min-length>0</min-length>
+          </attribute-definition>
+    </custom-attribute-definitions>
+  </type-extension>
 </metadata>


### PR DESCRIPTION
Based on the platform account ID, if shopper already has Bolt external authenticated account, update the existing account addresses and payments.
If the shopper already has a regular SFCC account, create an external Bolt profile, save Bolt addresses and payments.
Otherwise, create a new external authenticated (passwordless) account.

Asana: https://app.asana.com/0/0/1205890736689968/f