### PR TITLE
Fix session login double firing

### DIFF
--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
@@ -5,15 +5,6 @@ var constants = require('./constant.js');
 var analytics = require('./analytics.js');
 
 /**
- * Auto log the user into their bolt account
- * @param {Object} loginModalComponent - authorization component
- * @returns {Promise} The returned promise to fetch account details
- */
-async function sessionLogin(loginModalComponent) {
-    await loginModalComponent.attemptLogin({});
-}
-
-/**
  * This function uses the authCode and scope returned from authorizeWithEmail
  * after the user enters the 6 digits OTP code
  * It makes a call to Bolt-FetchOAuthToken controller to fetch Oauth token & refresh token
@@ -111,14 +102,6 @@ exports.logout = function () {
             }
         }
     });
-};
-
-/**
- * detect bolt session login
- * @param {Object} loginModalComponent - authorization component
- */
-exports.detectSessionLogin = function (loginModalComponent) {
-    sessionLogin(loginModalComponent);
 };
 
 /**

--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/account.js
@@ -10,13 +10,7 @@ var analytics = require('./analytics.js');
  * @returns {Promise} The returned promise to fetch account details
  */
 async function sessionLogin(loginModalComponent) {
-    const authorizeResp = await loginModalComponent.attemptLogin({});
-    if (!authorizeResp) return;
-    const OAuthResp = await authenticateUserWithCode(
-        authorizeResp.authorizationCode,
-        authorizeResp.scope
-    );
-    return getAccountDetails(OAuthResp.accessToken); // eslint-disable-line consistent-return
+    await loginModalComponent.attemptLogin({});
 }
 
 /**

--- a/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/eventListenerRegistration.js
+++ b/cartridges/int_bolt_embedded_sfra/cartridge/client/default/js/eventListenerRegistration.js
@@ -24,7 +24,7 @@ $(document).ready(async function () {
     const boltSFCCSessionLogoutCookie = account.getCookie('bolt_sfcc_session_logout');
 
     if (!isBoltShopperLoggedIn && boltSFCCSessionLogoutCookie !== 'true') {
-        account.detectSessionLogin(loginModalComponent);
+        loginModalComponent.attemptLogin({});
     }
 
     account.setupListeners();


### PR DESCRIPTION
Session login code is firing two calls to fetch calls after a successful login. our new `.attemptLogin({})` call fires `"login_complete"` event, but the catridge also does manual account gets. Double calls cause both get account calls to fail. We remove one of them.